### PR TITLE
[gpu-notebook] downgrade scipy to 1.8.1

### DIFF
--- a/gpu-notebook/requirements.txt
+++ b/gpu-notebook/requirements.txt
@@ -1,4 +1,3 @@
-tensorflow==2.8.0
 keras
 ipywidgets
 nbresuse
@@ -7,7 +6,6 @@ scikit-image
 matplotlib
 numpy
 pandas
-scipy
 statsmodels
 sympy
 xlrd
@@ -26,3 +24,5 @@ pydot
 pyyaml
 pypdf2
 pdfkit
+scipy==1.8.1
+tensorflow==2.8.0


### PR DESCRIPTION
Downgrade scipy version to 1.8.1 to fix GLIBCXX version issue.
Fixes #26  